### PR TITLE
[WIP] api-client: add circuit breaker with resillience4j

### DIFF
--- a/blibli-backend-framework-api-client/README.md
+++ b/blibli-backend-framework-api-client/README.md
@@ -341,6 +341,10 @@ or using properties :
 blibli.backend.apiclient.configs.exampleApiClient.codec-customizers[0]=com.blibli.oss.backend.example.client.customizer.ExampleCodecCustomizer
 ```
 
+## Circuit Breaker
+
+// TODO write this
+
 ## Supported Body
 
 API Client Module is modular library, it support request body resolver to translate from `@RequestBody` parameter to low level http request.

--- a/blibli-backend-framework-api-client/pom.xml
+++ b/blibli-backend-framework-api-client/pom.xml
@@ -34,6 +34,17 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-framework-common</artifactId>
+      <!-- MUST be same as the one in spring-cloud-starter-circuitbreaker-reactor-resilience4j -->
+      <version>1.1.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>

--- a/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/properties/ApiClientProperties.java
+++ b/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/properties/ApiClientProperties.java
@@ -5,6 +5,7 @@ import com.blibli.oss.backend.apiclient.customizer.ApiClientTcpClientCustomizer;
 import com.blibli.oss.backend.apiclient.customizer.ApiClientWebClientCustomizer;
 import com.blibli.oss.backend.apiclient.error.ApiErrorResolver;
 import com.blibli.oss.backend.apiclient.interceptor.ApiClientInterceptor;
+import io.github.resilience4j.common.circuitbreaker.configuration.CircuitBreakerConfigurationProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -77,6 +78,8 @@ public class ApiClientProperties {
     private List<Class<? extends ApiClientTcpClientCustomizer>> tcpClientCustomizers = new ArrayList<>();
 
     private Class<? extends ApiErrorResolver> errorResolver;
+
+    private CircuitBreakerConfigurationProperties.InstanceProperties circuitBreaker;
 
   }
 

--- a/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/CircuitBreakingClientTest.java
+++ b/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/CircuitBreakingClientTest.java
@@ -1,0 +1,46 @@
+package com.blibli.oss.backend.apiclient;
+
+import com.blibli.oss.backend.apiclient.client.HelloApiClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(classes = TestApplication.class)
+public class CircuitBreakingClientTest {
+
+  // TODO create dedicated api client with small windowSize, so testing is easier
+  @Autowired
+  private HelloApiClient helloApiClient;
+
+  @Test
+  void testFallback() {
+    String response;
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+
+    // From now, circuit is closed
+    // TODO Assert circuitbreaker state machine
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+    response = helloApiClient.hello().block();
+    assertEquals("Fallback", response);
+  }
+}

--- a/blibli-backend-framework-api-client/src/test/resources/application.properties
+++ b/blibli-backend-framework-api-client/src/test/resources/application.properties
@@ -9,7 +9,8 @@ blibli.backend.apiclient.configs.helloApiClient.fallback=com.blibli.oss.backend.
 spring.http.log-request-details=true
 logging.level.org.springframework.web.reactive.function.client.ExchangeFunctions=TRACE
 logging.level.reactor.netty.http.client=DEBUG
-
+logging.level.io.github.resilience4j.circuitbreaker.internal.CircuitBreakerStateMachine=DEBUG
+resilience4j.circuitbreaker.test.
 blibli.backend.reactor.scheduler.configs.exampleClient.type=thread_pool
 blibli.backend.reactor.scheduler.configs.exampleClient.thread-pool.allow-core-thread-time-out=false
 blibli.backend.reactor.scheduler.configs.exampleClient.thread-pool.core-pool-size=10


### PR DESCRIPTION
This add circuit breaking mechanism using [spring-cloud-circuitbreaker](https://spring.io/projects/spring-cloud-circuitbreaker) and [resillience4j](https://resilience4j.readme.io/docs/circuitbreaker) implementation.

TODO
- [x] Draft POC of working ApiClient with circuit breaker - DONE, see sample log on `helloApiClient` is OPEN thus prevent HTTP API call to happen.
- [ ] Expose circuit breaker configuration to `ApiClientProperties`
- [ ] Proper test
- [ ] Update readme

```
2020-06-11 03:10:30.644 ERROR [,,,] 477254 --- [           main] c.b.o.b.a.error.DefaultApiErrorResolver  : CircuitBreaker 'helloApiClient' is OPEN and does not permit further calls

io.github.resilience4j.circuitbreaker.CallNotPermittedException: CircuitBreaker 'helloApiClient' is OPEN and does not permit further calls
```