### PR TITLE
Adding query params able to be configured via properties

### DIFF
--- a/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/aop/ApiClientMethodInterceptor.java
+++ b/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/aop/ApiClientMethodInterceptor.java
@@ -48,7 +48,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -294,6 +301,8 @@ public class ApiClientMethodInterceptor implements MethodInterceptor, Initializi
         builder.queryParam(paramName, arguments[position]);
       }
     });
+
+    metadata.getProperties().getParams().forEach(builder::queryParam);
 
     Map<String, Object> uriVariables = new HashMap<>();
     metadata.getPathVariablePositions().get(methodName).forEach((paramName, position) -> {

--- a/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/properties/ApiClientProperties.java
+++ b/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/properties/ApiClientProperties.java
@@ -68,6 +68,8 @@ public class ApiClientProperties {
 
     private Map<String, String> headers = new HashMap<>();
 
+    private Map<String, String> params = new HashMap<>();
+
     private List<Class<? extends ApiClientInterceptor>> interceptors = new ArrayList<>();
 
     private List<Class<? extends ApiClientWebClientCustomizer>> webClientCustomizers = new ArrayList<>();

--- a/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/properties/PropertiesHelper.java
+++ b/blibli-backend-framework-api-client/src/main/java/com/blibli/oss/backend/apiclient/properties/PropertiesHelper.java
@@ -28,6 +28,8 @@ public class PropertiesHelper {
         target.setWriteTimeout(source.getWriteTimeout());
       }
 
+      source.getParams().forEach((key, value) -> target.getParams().put(key, value));
+
       source.getHeaders().forEach((key, value) -> target.getHeaders().put(key, value));
 
       source.getInterceptors().forEach(aClass -> target.getInterceptors().add(aClass));

--- a/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/SleuthApiClientTest.java
+++ b/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/SleuthApiClientTest.java
@@ -50,4 +50,22 @@ public class SleuthApiClientTest {
       .jsonPath("$.value[1]").isEqualTo("Kurniawan")
       .jsonPath("$.value[2]").isEqualTo("Khannedy");
   }
+
+  @Test
+  void testParam() {
+    webTestClient.get()
+      .uri(uriBuilder -> uriBuilder.path("/test-param").build())
+      .exchange()
+      .expectStatus()
+      .is2xxSuccessful()
+      .expectBody()
+      .jsonPath("$.value.clientId[0]")
+      .isEqualTo("clientId")
+      .jsonPath("$.value.storeId[0]")
+      .isEqualTo("storeId")
+      .jsonPath("$.value.channelId[0]")
+      .isEqualTo("channelId")
+      .jsonPath("$.value.username[0]")
+      .isEqualTo("username");
+  }
 }

--- a/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/client/SleuthApiClient.java
+++ b/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/client/SleuthApiClient.java
@@ -29,4 +29,11 @@ public interface SleuthApiClient {
   )
   Mono<GenericResponse<List<String>>> names(@RequestParam("names") List<String> names);
 
+  @RequestMapping(
+    method = RequestMethod.GET,
+    value = "/param",
+    produces = MediaType.APPLICATION_JSON_VALUE
+  )
+  Mono<GenericResponse<Object>> param();
+
 }

--- a/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/controller/SleuthController.java
+++ b/blibli-backend-framework-api-client/src/test/java/com/blibli/oss/backend/apiclient/controller/SleuthController.java
@@ -68,4 +68,20 @@ public class SleuthController {
     return Mono.just(response);
   }
 
+  @GetMapping(
+    value = "/param",
+    produces = MediaType.APPLICATION_JSON_VALUE
+  )
+  public Mono<GenericResponse<Object>> param(ServerWebExchange exchange) {
+    return Mono.just(new GenericResponse<>(exchange.getRequest().getQueryParams()));
+  }
+
+  @GetMapping(
+    value = "/test-param",
+    produces = MediaType.APPLICATION_JSON_VALUE
+  )
+  public Mono<GenericResponse<Object>> testParam() {
+    return sleuthApiClient.param();
+  }
+
 }

--- a/blibli-backend-framework-api-client/src/test/resources/application.properties
+++ b/blibli-backend-framework-api-client/src/test/resources/application.properties
@@ -2,6 +2,10 @@ blibli.backend.apiclient.packages=com.blibli.oss.backend.apiclient.client
 blibli.backend.apiclient.configs.exampleClient.url=http://localhost:8089
 
 blibli.backend.apiclient.configs.sleuthApiClient.url=http://localhost:15234
+blibli.backend.apiclient.configs.sleuthApiClient.params.storeId=storeId
+blibli.backend.apiclient.configs.sleuthApiClient.params.channelId=channelId
+blibli.backend.apiclient.configs.sleuthApiClient.params.clientId=clientId
+blibli.backend.apiclient.configs.sleuthApiClient.params.username=username
 
 blibli.backend.apiclient.configs.helloApiClient.url=http://localhost:8089
 blibli.backend.apiclient.configs.helloApiClient.fallback=com.blibli.oss.backend.apiclient.client.HelloApiClientFallback


### PR DESCRIPTION
Right now, only headers can be configured via properties, static params can be supported with the following approach for clients.